### PR TITLE
Cloneable config and always return our date types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
 
+## 0.2.0 - 2024-11-24
+* Export only DateTime types from the '
+* Changed CodecConfig to `EntryCodecConfig` so it better matches EntryCodec when exporting.
+* Change type for `EntryCodecConfig.map_comment_context` to
+  `Option<fn(HashMap<Bytes, Bytes>)...` so that `EntryCodecConfig` can derive `Clone`.
+* Minor documentation improvements
+
 ## 0.1.0 - 2024-11-19
 Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysql-slowlog-parser"
-version = "0.1.0"
+version = "0.2.0"
 description = "Streaming parser for MySQL slowlogs"
 edition = "2021"
 license = "MIT"
@@ -15,13 +15,16 @@ bytes = "1.4.0"
 env_logger = "0.11.5"
 futures = "0.3.26"
 winnow = {  version = "0.6.20", features = ["default"] }
-winnow_iso8601 = {  version = "0.2.0"}
+winnow_iso8601 = {  version = "0.2.0", features = ["default"]}
 sqlparser = {version = "0.52.0", features = ["visitor"]}
 thiserror = "2.0.3"
 log = "0.4.17"
 time = {version = "0.3.36", features=["parsing"]}
 tokio = {version = "1.25.0", features = ["bytes", "fs", "io-std", "io-util", "rt", "rt-multi-thread", "macros"]}
 tokio-util = {version = "0.7.1", features = ["codec"]}
+
+[features]
+chrono = ["winnow_iso8601/chrono"]
 
 [[example]]
 name = "iterator"

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use futures::StreamExt;
 use mysql_slowlog_parser::{EntryCodec, EntrySqlType};
+use std::collections::HashMap;
 use tokio::fs::File;
 use tokio_util::codec::FramedRead;
 
@@ -17,17 +17,20 @@ async fn main() {
         match entry.sql_attributes.sql_type() {
             Some(st) => {
                 acc.insert(st, acc.get(&st).unwrap_or(&0) + 1);
-            },
+            }
             None => {
-               acc.insert(EntrySqlType::Unknown,acc.get(&EntrySqlType::Unknown).unwrap_or(&0) + 1);
+                acc.insert(
+                    EntrySqlType::Unknown,
+                    acc.get(&EntrySqlType::Unknown).unwrap_or(&0) + 1,
+                );
             }
         }
-        
+
         acc
     });
 
     let type_counts = future.await;
-    
+
     for (k, v) in type_counts {
         println!("{}: {}", k, v);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,16 +105,15 @@ impl Default for EntryMasking {
 }
 
 /// Struct to pass along configuration values to codec
-#[derive(Default)]
-pub struct CodecConfig {
+#[derive(Copy, Clone, Default)]
+pub struct EntryCodecConfig {
     /// type of masking to use when parsing SQL
     pub masking: EntryMasking,
     /// mapping function in order to find specific key entries
-    pub map_comment_context:
-        Option<Box<dyn Fn(HashMap<Bytes, Bytes>) -> Option<SqlStatementContext>>>,
+    pub map_comment_context: Option<fn(HashMap<Bytes, Bytes>) -> Option<SqlStatementContext>>,
 }
 
-impl Debug for CodecConfig {
+impl Debug for EntryCodecConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.masking)?;
         write!(f, "map_comment_context: fn")


### PR DESCRIPTION
Small changes I came across when trying to use the parser from a separate project. Bumps version to 0.2.0